### PR TITLE
Fix for crypto/tls in go 1.3

### DIFF
--- a/xmpp/xmpp.go
+++ b/xmpp/xmpp.go
@@ -72,7 +72,7 @@ func (c *Conn) StartTLS() {
 }
 
 func (c *Conn) UseTLS() {
-	c.outgoing = tls.Client(c.outgoing, nil)
+	c.outgoing = tls.Client(c.outgoing, &tls.Config{ServerName: "chat.hipchat.com"})
 	c.incoming = xml.NewDecoder(c.outgoing)
 }
 


### PR DESCRIPTION
Fix for crypto/tls in go 1.3
(Error: tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config)
