### PR TITLE
Ability to receive and send private messages

### DIFF
--- a/example/discover_self.go
+++ b/example/discover_self.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/daneharrigan/hipchat"
+
+	"github.com/cjhubert/hipchat"
 )
 
 func main() {

--- a/example/hello.go
+++ b/example/hello.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/daneharrigan/hipchat"
+
+	"github.com/cjhubert/hipchat"
 )
 
 func main() {

--- a/example/reply.go
+++ b/example/reply.go
@@ -3,7 +3,8 @@ package main
 import (
 	"fmt"
 	"strings"
-	"github.com/daneharrigan/hipchat"
+
+	"github.com/cjhubert/hipchat"
 )
 
 func main() {

--- a/hipchat.go
+++ b/hipchat.go
@@ -2,8 +2,9 @@ package hipchat
 
 import (
 	"errors"
-	"github.com/daneharrigan/hipchat/xmpp"
 	"time"
+
+	"github.com/daneharrigan/hipchat/xmpp"
 )
 
 var (
@@ -197,7 +198,7 @@ func (c *Client) listen() {
 			}
 		case "message" + xmpp.NsJabberClient:
 			attr := xmpp.ToMap(element.Attr)
-			if attr["type"] != "groupchat" {
+			if attr["type"] != "groupchat" && attr["type"] != "chat" {
 				continue
 			}
 

--- a/hipchat.go
+++ b/hipchat.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/daneharrigan/hipchat/xmpp"
+	"github.com/cjhubert/hipchat/xmpp"
 )
 
 var (

--- a/xmpp/xmpp.go
+++ b/xmpp/xmpp.go
@@ -9,6 +9,7 @@ import (
 	"html"
 	"io"
 	"net"
+	"strings"
 )
 
 const (
@@ -26,7 +27,7 @@ const (
 	xmlIqGet       = "<iq from='%s' to='%s' id='%s' type='get'><query xmlns='%s'/></iq>"
 	xmlPresence    = "<presence from='%s'><show>%s</show></presence>"
 	xmlMUCPresence = "<presence id='%s' to='%s' from='%s'><x xmlns='%s'/></presence>"
-	xmlMUCMessage  = "<message from='%s' id='%s' to='%s' type='groupchat'><body>%s</body></message>"
+	xmlMUCMessage  = "<message from='%s' id='%s' to='%s' type='%s'><body>%s</body></message>"
 )
 
 type required struct{}
@@ -135,7 +136,15 @@ func (c *Conn) MUCPresence(roomId, jid string) {
 }
 
 func (c *Conn) MUCSend(to, from, body string) {
-	fmt.Fprintf(c.outgoing, xmlMUCMessage, from, id(), to, html.EscapeString(body))
+	// Default message type to groupchat, which will send a
+	// message to a room
+	messageType := "groupchat"
+	if strings.HasSuffix(to, "@chat.hipchat.com") {
+		// if the to string ends with @chat.hipchat.com, we're being asked to
+		// send to a user, so change message type to chat
+		messageType = "chat"
+	}
+	fmt.Fprintf(c.outgoing, xmlMUCMessage, from, id(), to, messageType, html.EscapeString(body))
 }
 
 func (c *Conn) Roster(from, to string) {


### PR DESCRIPTION
This adds the ability to receive and send private messages.

Received private messages are added onto the Messages channel, so the user implementing it will need to parse the `message.From` themselves to check whether it was from a room or from a user.

When sending a message, it will check if the `to` address contains the text `@chat.hipchat.com`. This means that we're sending it to a user instead of a room (which would be `@conf.hipchat.com`), and changes the message type of the xml accordingly.