### PR TITLE
Update channel handling to be non-blocking

### DIFF
--- a/example/discover_self.go
+++ b/example/discover_self.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/daneharrigan/hipchat"
 )
 
@@ -16,17 +17,15 @@ func main() {
 		return
 	}
 
-	var fullName string
-	var mentionName string
+	client.RequestUsers()
 
-	for _, user := range client.Users() {
-		if user.Id == client.Id {
-			fullName = user.Name
-			mentionName = user.MentionName
-			break
+	select {
+	case users := <-client.Users():
+		for _, user := range users {
+			if user.Id == client.Id {
+				fmt.Printf("name: %s\n", user.Name)
+				fmt.Printf("mention: %s\n", user.MentionName)
+			}
 		}
 	}
-
-	fmt.Printf("name: %s\n", fullName)
-	fmt.Printf("mention: %s\n", mentionName)
 }

--- a/example/hello.go
+++ b/example/hello.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/daneharrigan/hipchat"
 )
 

--- a/example/reply.go
+++ b/example/reply.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"strings"
+
 	"github.com/daneharrigan/hipchat"
 )
 
@@ -22,9 +23,16 @@ func main() {
 
 	client.Status("chat")
 	client.Join(roomJid, fullName)
-	for message := range client.Messages() {
-		if strings.HasPrefix(message.Body, "@"+mentionName) {
-			client.Say(roomJid, fullName, "Hello")
+
+	go func() {
+		for {
+			select {
+			case message := <-client.Messages():
+				if strings.HasPrefix(message.Body, "@"+mentionName) {
+					client.Say(roomJid, fullName, "Hello")
+				}
+			}
 		}
-	}
+	}()
+	select {}
 }

--- a/hipchat.go
+++ b/hipchat.go
@@ -2,8 +2,9 @@ package hipchat
 
 import (
 	"errors"
-	"github.com/daneharrigan/hipchat/xmpp"
 	"time"
+
+	"github.com/daneharrigan/hipchat/xmpp"
 )
 
 var (
@@ -87,16 +88,14 @@ func (c *Client) Messages() <-chan *Message {
 	return c.receivedMessage
 }
 
-// Rooms returns an slice of Room structs.
-func (c *Client) Rooms() []*Room {
-	c.requestRooms()
-	return <-c.receivedRooms
+// Rooms returns a channel of Room slices
+func (c *Client) Rooms() <-chan []*Room {
+	return c.receivedRooms
 }
 
-// Users returns a slice of User structs.
-func (c *Client) Users() []*User {
-	c.requestUsers()
-	return <-c.receivedUsers
+// Users returns a channel of User slices
+func (c *Client) Users() <-chan []*User {
+	return c.receivedUsers
 }
 
 // Status sends a string to HipChat to indicate whether the client is available
@@ -126,11 +125,15 @@ func (c *Client) KeepAlive() {
 	}
 }
 
-func (c *Client) requestRooms() {
+// RequestRooms will send an outgoing request to get
+// the room information for all rooms
+func (c *Client) RequestRooms() {
 	c.connection.Discover(c.Id, conf)
 }
 
-func (c *Client) requestUsers() {
+// RequestUsers will send an outgoing request to get
+// the user information for all users
+func (c *Client) RequestUsers() {
 	c.connection.Roster(c.Id, host)
 }
 


### PR DESCRIPTION
This is a PR to fix the issue discussed in #8. We've been using the code with these changes for a couple weeks now and none of our bots are hanging like they used to.

I also updated the examples to be use the channels instead, as @fedyakin shows in the above issue, a normal structure would probably look something like this:

```go
go func() {
    for {
        select {
        case message := <-client.Messages():
            log.Printf("Received message: %v", message)
        case rooms := <-client.Rooms():
            log.Printf("Received rooms: %v", rooms)
        case users := <-client.Users():
            log.Printf("Received users: %v", users)
        }
    }
}()
```

Let me know if you have any question.