### PR TITLE
allow direct messages

### DIFF
--- a/hipchat.go
+++ b/hipchat.go
@@ -210,9 +210,6 @@ func (c *Client) listen() {
 			}
 		case "message" + xmpp.NsJabberClient:
 			attr := xmpp.ToMap(element.Attr)
-			if attr["type"] != "groupchat" {
-				continue
-			}
 
 			c.receivedMessage <- &Message{
 				From: attr["from"],


### PR DESCRIPTION
I'm not sure why only public messages are delivered. For my use case, I've needed to enable private messages as well.