### PR TITLE
implement PrivSay to send private messages

### DIFF
--- a/hipchat.go
+++ b/hipchat.go
@@ -123,7 +123,14 @@ func (c *Client) Join(roomId, resource string) {
 // Say accepts a room id, the name of the client in the room, and the message
 // body and sends the message to the HipChat room.
 func (c *Client) Say(roomId, name, body string) {
-	c.connection.MUCSend(roomId, c.Id+"/"+name, body)
+	c.connection.MUCSend("groupchat", roomId, c.Id+"/"+name, body)
+}
+
+// PrivSay accepts a client id, the name of the client, and the message
+// body and sends the private message to the HipChat
+// user.
+func (c *Client) PrivSay(user, name, body string) {
+	c.connection.MUCSend("chat", user, c.Id+"/"+name, body)
 }
 
 // KeepAlive is meant to run as a goroutine. It sends a single whitespace
@@ -218,4 +225,5 @@ func (c *Client) listen() {
 			}
 		}
 	}
+	panic("unreachable")
 }

--- a/xmpp/xmpp.go
+++ b/xmpp/xmpp.go
@@ -26,7 +26,7 @@ const (
 	xmlIqGet       = "<iq from='%s' to='%s' id='%s' type='get'><query xmlns='%s'/></iq>"
 	xmlPresence    = "<presence from='%s'><show>%s</show></presence>"
 	xmlMUCPresence = "<presence id='%s' to='%s' from='%s'><x xmlns='%s'/></presence>"
-	xmlMUCMessage  = "<message from='%s' id='%s' to='%s' type='groupchat'><body>%s</body></message>"
+	xmlMUCMessage  = "<message from='%s' id='%s' to='%s' type='%s'><body>%s</body></message>"
 )
 
 type required struct{}
@@ -134,8 +134,8 @@ func (c *Conn) MUCPresence(roomId, jid string) {
 	fmt.Fprintf(c.outgoing, xmlMUCPresence, id(), roomId, jid, NsMuc)
 }
 
-func (c *Conn) MUCSend(to, from, body string) {
-	fmt.Fprintf(c.outgoing, xmlMUCMessage, from, id(), to, html.EscapeString(body))
+func (c *Conn) MUCSend(mtype, to, from, body string) {
+	fmt.Fprintf(c.outgoing, xmlMUCMessage, from, id(), to, mtype, html.EscapeString(body))
 }
 
 func (c *Conn) Roster(from, to string) {


### PR DESCRIPTION
Private messages are 1-1 messages between two parties,
using an XMPP type of 'chat'.  In order to retain full
backwards compatibility, this commit adds the new function
'PrivSay' rather than changing the 'Say' function to
require an additional flag.