### PR TITLE
XML escape password string

### DIFF
--- a/hipchat.go
+++ b/hipchat.go
@@ -1,6 +1,8 @@
 package hipchat
 
 import (
+	"bytes"
+	"encoding/xml"
 	"errors"
 	"time"
 
@@ -63,9 +65,14 @@ func NewClient(user, pass, resource string) (*Client, error) {
 func NewClientWithServerInfo(user, pass, resource, host, conf string) (*Client, error) {
 	connection, err := xmpp.Dial(host)
 
+	var b bytes.Buffer
+	if err := xml.EscapeText(&b, []byte(pass)); err != nil {
+		return nil, err
+	}
+
 	c := &Client{
 		Username: user,
-		Password: pass,
+		Password: b.String(),
 		Resource: resource,
 		Id:       user + "@" + host,
 


### PR DESCRIPTION
Passwords containing [Predefined XML entities](https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Predefined_entities_in_XML) should be escaped when used during auth.

## Before
```lang=xml
<iq type='set' id='1234567890'><query xmlns='jabber:iq:auth'><username>12345_67890</username><password>Foob&R</password><resource>bot</resource></query></iq>
client error: read: connection reset by peer
```

## After
```lang=xml
<iq type='set' id='1234567890'><query xmlns='jabber:iq:auth'><username>12345_67890</username><password>Foob&amp;R</password><resource>bot</resource></query></iq>
```