### PR TITLE
Add a channel for unsupported xmpp event types

### DIFF
--- a/hipchat.go
+++ b/hipchat.go
@@ -165,7 +165,10 @@ func (c *Client) PrivSay(user, name, body string) {
 // idling after 150 seconds.
 func (c *Client) KeepAlive() {
 	for _ = range time.Tick(60 * time.Second) {
-		c.connection.KeepAlive()
+		err := c.connection.KeepAlive()
+		if err != nil {
+			return
+		}
 	}
 }
 
@@ -174,7 +177,10 @@ func (c *Client) KeepAlive() {
 // idling after 150 seconds.
 func (c *Client) KeepAliveBy(sec time.Duration) {
 	for _ = range time.Tick(sec * time.Second) {
-		c.connection.KeepAlive()
+		err := c.connection.KeepAlive()
+		if err != nil {
+			return
+		}
 	}
 }
 

--- a/hipchat.go
+++ b/hipchat.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/daneharrigan/hipchat/xmpp"
+	"github.com/lusis/hipchat/xmpp"
 )
 
 const (
@@ -136,8 +136,9 @@ func (c *Client) Join(roomId, resource string) {
 
 // Part accepts the room id to part.
 func (c *Client) Part(roomId, name string) {
-	c.connection.MUCPart(roomId+"/"+name)
+	c.connection.MUCPart(roomId + "/" + name)
 }
+
 // Say accepts a room id, the name of the client in the room, and the message
 // body and sends the message to the HipChat room.
 func (c *Client) Say(roomId, name, body string) {
@@ -156,6 +157,15 @@ func (c *Client) PrivSay(user, name, body string) {
 // idling after 150 seconds.
 func (c *Client) KeepAlive() {
 	for _ = range time.Tick(60 * time.Second) {
+		c.connection.KeepAlive()
+	}
+}
+
+// KeepAlive is meant to run as a goroutine. It sends a single whitespace
+// character to HipChat every arbitrary seconds. This keeps the connection from
+// idling after 150 seconds.
+func (c *Client) KeepAliveBy(sec time.Duration) {
+	for _ = range time.Tick(sec * time.Second) {
 		c.connection.KeepAlive()
 	}
 }

--- a/xmpp/xmpp.go
+++ b/xmpp/xmpp.go
@@ -157,8 +157,15 @@ func (c *Conn) Roster(from, to string) {
 	fmt.Fprintf(c.outgoing, xmlIqGet, from, to, id(), NsIqRoster)
 }
 
-func (c *Conn) KeepAlive() {
-	fmt.Fprintf(c.outgoing, "<r/>")
+// KeepAlive sets a keepalive
+// we exit here to allow for handling of cases where we can't write to the xmpp server
+// so the user can decide
+func (c *Conn) KeepAlive() error {
+	_, err := fmt.Fprintf(c.outgoing, "<r/>")
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func Dial(host string) (*Conn, error) {

--- a/xmpp/xmpp.go
+++ b/xmpp/xmpp.go
@@ -51,6 +51,10 @@ type item struct {
 	Topic           string `xml:"x>topic"`
 }
 
+type ack struct {
+	Ack string `xml:"a"`
+}
+
 type query struct {
 	XMLName xml.Name `xml:"query"`
 	Items   []*item  `xml:"item"`
@@ -155,7 +159,7 @@ func (c *Conn) Roster(from, to string) {
 }
 
 func (c *Conn) KeepAlive() {
-	fmt.Fprintf(c.outgoing, " ")
+	fmt.Fprintf(c.outgoing, "<r/>")
 }
 
 func Dial(host string) (*Conn, error) {

--- a/xmpp/xmpp.go
+++ b/xmpp/xmpp.go
@@ -51,7 +51,7 @@ type item struct {
 	Topic           string `xml:"x>topic"`
 }
 
-type ack struct {
+type Ack struct {
 	Ack string `xml:"a"`
 }
 
@@ -115,7 +115,6 @@ func (c *Conn) Next() (xml.StartElement, error) {
 			if element.Name.Local == "" {
 				return element, errors.New("invalid xml response")
 			}
-
 			return element, nil
 		}
 	}

--- a/xmpp/xmpp.go
+++ b/xmpp/xmpp.go
@@ -99,9 +99,9 @@ func (c *Conn) Features() *features {
 }
 
 func (c *Conn) Next() (xml.StartElement, error) {
-	var element xml.StartElement
 
 	for {
+		var element xml.StartElement
 		var err error
 		var t xml.Token
 		t, err = c.incoming.Token()

--- a/xmpp/xmpp.go
+++ b/xmpp/xmpp.go
@@ -161,7 +161,7 @@ func (c *Conn) Roster(from, to string) {
 // we exit here to allow for handling of cases where we can't write to the xmpp server
 // so the user can decide
 func (c *Conn) KeepAlive() error {
-	_, err := fmt.Fprintf(c.outgoing, "<r/>")
+	_, err := fmt.Fprintf(c.outgoing, " ")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In the process of troubleshooting issues with dying connections I made the change for configurable KeepAlives. When that still didn't solve the problem, I added a new channel for unhandled events as well as changing the way keep alives are done to use the documented mechanism for pings here:

https://ecosystem.atlassian.net/wiki/display/HCDEV/HipChat+XMPP+Protocol+Documentation#HipChatXMPPProtocolDocumentation-Pings (the XEP-0198 implementation)

Instead of creating a specific channel for acks, I just used the new channel so my upstream application could handle them. 
