### PR TITLE
Allow configuration of client domain for Hipchat Server

### DIFF
--- a/hipchat.go
+++ b/hipchat.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	defaultHost = "chat.hipchat.com"
-	defaultConf = "conf.hipchat.com"
+	defaultHost   = "chat.hipchat.com"
+	defaultDomain = "chat.hipchat.com"
+	defaultConf   = "conf.hipchat.com"
 )
 
 // A Client represents the connection between the application to the HipChat
@@ -29,6 +30,7 @@ type Client struct {
 	receivedRooms   chan []*Room
 	receivedMessage chan *Message
 	host            string
+	domain          string
 	conf            string
 }
 
@@ -64,12 +66,12 @@ type Room struct {
 // NewClient creates a new Client connection from the user name, password and
 // resource passed to it. It uses default host URL and conf URL.
 func NewClient(user, pass, resource string) (*Client, error) {
-	return NewClientWithServerInfo(user, pass, resource, defaultHost, defaultConf)
+	return NewClientWithServerInfo(user, pass, resource, defaultHost, defaultDomain, defaultConf)
 }
 
 // NewClientWithServerInfo creates a new Client connection from the user name, password,
 // resource, host URL and conf URL passed to it.
-func NewClientWithServerInfo(user, pass, resource, host, conf string) (*Client, error) {
+func NewClientWithServerInfo(user, pass, resource, host, domain, conf string) (*Client, error) {
 	connection, err := xmpp.Dial(host)
 
 	var b bytes.Buffer
@@ -81,7 +83,7 @@ func NewClientWithServerInfo(user, pass, resource, host, conf string) (*Client, 
 		Username: user,
 		Password: b.String(),
 		Resource: resource,
-		Id:       user + "@" + host,
+		Id:       user + "@" + domain,
 
 		// private
 		connection:      connection,
@@ -90,6 +92,7 @@ func NewClientWithServerInfo(user, pass, resource, host, conf string) (*Client, 
 		receivedRooms:   make(chan []*Room),
 		receivedMessage: make(chan *Message),
 		host:            host,
+		domain:          domain,
 		conf:            conf,
 	}
 
@@ -136,8 +139,9 @@ func (c *Client) Join(roomId, resource string) {
 
 // Part accepts the room id to part.
 func (c *Client) Part(roomId, name string) {
-	c.connection.MUCPart(roomId+"/"+name)
+	c.connection.MUCPart(roomId + "/" + name)
 }
+
 // Say accepts a room id, the name of the client in the room, and the message
 // body and sends the message to the HipChat room.
 func (c *Client) Say(roomId, name, body string) {
@@ -169,7 +173,7 @@ func (c *Client) RequestRooms() {
 // RequestUsers will send an outgoing request to get
 // the user information for all users
 func (c *Client) RequestUsers() {
-	c.connection.Roster(c.Id, c.host)
+	c.connection.Roster(c.Id, c.domain)
 }
 
 func (c *Client) authenticate() error {


### PR DESCRIPTION
Quick PR to fix #20 

There are probably more elegant ways to fix this, like having a more generic 'xmppDomain' parameter to NewClientWithServerInfo() with a default of 'hipchat.com' and then defining clientDomain like

`"chat." + xmppDomain`

and mucDomain like

`"conf." + xmppDomain`

Let me know what you think.